### PR TITLE
⏫ use detox for parallel builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: python
 python:
   - "2.7"
-  - "3.5"
   - "3.6"
-install: pip install tox-travis
-script: tox
+install: pip install tox-travis detox
+script: detox

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ setup(
     classifiers=[
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Operating System :: OS Independent",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,15 @@
 # in multiple virtualenvs. This configuration file will run the
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
+#
+# Note, you can also install detox ("pip install detox") to execute tox in
+# parallel.
+
 [build-system]
 requires = [ "setuptools >= 35.0.2", "wheel >= 0.32.0"]
 
 [tox]
-envlist = py27, py35, py36, black
+envlist = py27, py36, black
 
 [testenv]
 deps =
@@ -15,7 +19,7 @@ whitelist_externals =
     /bin/bash
 commands =
     # super simple test time.
-    # pylint time
+    # pylint
     bash -c "pylint ./**/*.py"
     # confirm we can build the wheel with no errors
     {envpython} setup.py bdist_wheel
@@ -27,7 +31,7 @@ commands =
 [testenv:black]
 deps=black
 basepython=python3
-; setenv =
-;     LC_ALL=C.UTF-8
-;     LANG=C.UTF-8
-commands=black --check --verbose .
+commands=
+    # install the package to pick up requirements
+    pip install .
+    black --check --verbose .


### PR DESCRIPTION
Detox runs tox in parallel and is faster; in my testing, 19s for detox
vs 44s for plain tox on a clean repo!